### PR TITLE
Peg wheel to 0.31.1 due to breaking change with archive module

### DIFF
--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1114,7 +1114,7 @@ def release(_, verbose=False, no_stash=False):
     if branch_name != BRANCH_MASTER:
         if not RE_VERSION_BRANCH_MAJOR.match(branch_name) and not RE_VERSION_BRANCH_MINOR.match(branch_name):
             _error_output(
-                'You are currently on branch "{}" instead of "master." You should only release from master or version ' # noqa: E501, W605
+                'You are currently on branch "{}" instead of "master." You should only release from master or version '  # noqa: E501, W605
                 'branches, and this does not appear to be a version branch (must match \d+\.x\.x or \d+.\d+\.x). '
                 '\nCanceling release!',
                 branch_name,

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1114,8 +1114,8 @@ def release(_, verbose=False, no_stash=False):
     if branch_name != BRANCH_MASTER:
         if not RE_VERSION_BRANCH_MAJOR.match(branch_name) and not RE_VERSION_BRANCH_MINOR.match(branch_name):
             _error_output(
-                'You are currently on branch "{}" instead of "master." You should only release from master or version '  # noqa: E501, W605
-                'branches, and this does not appear to be a version branch (must match \d+\.x\.x or \d+.\d+\.x). '
+                'You are currently on branch "{}" instead of "master." You should only release from master or version '
+                'branches, and this does not appear to be a version branch (must match \\d+\\.x\\.x or \\d+.\\d+\\.x). '
                 '\nCanceling release!',
                 branch_name,
             )

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -17,7 +17,7 @@ from wheel import archive
 
 RE_CHANGELOG_FILE_HEADER = re.compile(r'^=+$')
 RE_CHANGELOG_VERSION_HEADER = re.compile(r'^-+$')
-RE_FILE_EXTENSION = re.compile('\.\w+$')
+RE_FILE_EXTENSION = re.compile(r'\.\w+$')
 RE_VERSION = re.compile(r'^\d+\.\d+\.\d+([a-zA-Z\d.-]*[a-zA-Z\d]+)?$')
 RE_VERSION_BRANCH_MAJOR = re.compile(r'^\d+\.x\.x$')
 RE_VERSION_BRANCH_MINOR = re.compile(r'^\d+\.\d+\.x$')
@@ -1115,7 +1115,7 @@ def release(_, verbose=False, no_stash=False):
         if not RE_VERSION_BRANCH_MAJOR.match(branch_name) and not RE_VERSION_BRANCH_MINOR.match(branch_name):
             _error_output(
                 'You are currently on branch "{}" instead of "master." You should only release from master or version '
-                'branches, and this does not appear to be a version branch (must match \d+\.x\.x or \d+.\d+\.x). '
+                'branches, and this does not appear to be a version branch (must match \d+\.x\.x or \d+.\d+\.x). ' # noqa W605
                 '\nCanceling release!',
                 branch_name,
             )

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1114,8 +1114,8 @@ def release(_, verbose=False, no_stash=False):
     if branch_name != BRANCH_MASTER:
         if not RE_VERSION_BRANCH_MAJOR.match(branch_name) and not RE_VERSION_BRANCH_MINOR.match(branch_name):
             _error_output(
-                'You are currently on branch "{}" instead of "master." You should only release from master or version '
-                'branches, and this does not appear to be a version branch (must match \d+\.x\.x or \d+.\d+\.x). ' # noqa: W605
+                'You are currently on branch "{}" instead of "master." You should only release from master or version ' # noqa: E261, W605
+                'branches, and this does not appear to be a version branch (must match \d+\.x\.x or \d+.\d+\.x). '
                 '\nCanceling release!',
                 branch_name,
             )

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1114,7 +1114,7 @@ def release(_, verbose=False, no_stash=False):
     if branch_name != BRANCH_MASTER:
         if not RE_VERSION_BRANCH_MAJOR.match(branch_name) and not RE_VERSION_BRANCH_MINOR.match(branch_name):
             _error_output(
-                'You are currently on branch "{}" instead of "master." You should only release from master or version ' # noqa: E261, W605
+                'You are currently on branch "{}" instead of "master." You should only release from master or version ' # noqa: E501, W605
                 'branches, and this does not appear to be a version branch (must match \d+\.x\.x or \d+.\d+\.x). '
                 '\nCanceling release!',
                 branch_name,

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1115,7 +1115,7 @@ def release(_, verbose=False, no_stash=False):
         if not RE_VERSION_BRANCH_MAJOR.match(branch_name) and not RE_VERSION_BRANCH_MINOR.match(branch_name):
             _error_output(
                 'You are currently on branch "{}" instead of "master." You should only release from master or version '
-                'branches, and this does not appear to be a version branch (must match \d+\.x\.x or \d+.\d+\.x). ' # noqa W605
+                'branches, and this does not appear to be a version branch (must match \d+\.x\.x or \d+.\d+\.x). ' # noqa: W605
                 '\nCanceling release!',
                 branch_name,
             )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from invoke_release.version import __version__  # noqa: E402
 install_requires = [
     'invoke~=0.22.0',
     'six~=1.11.0',
-    'wheel',
+    'wheel~=0.31.1',
 ]
 
 tests_require = [


### PR DESCRIPTION
Summary: 0.32.x Has a breaking change that removed the archive module. This is a shorterm fix to peg wheel version.

Test Plan: Peer review

Reviewers: vince, nwilliams

Subscribers:

JIRA Issues: