### PR TITLE
Add support for pushing to a branch and not tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ configure_release_parameters(  # noqa: F405
 )
 ```
 
+If you would like `invoke-release` to push a release branch instead of pushing a commit to `master`, 
+add `use_pull_request=True` to `tasks.py`.
+If you do not want to push a tag to your remote repository, add `use_tag=False` to `tasks.py`.
+
 This assumes that the default Python source directory in your project is the same as the `module_name`, relative to the
 project root directory. This is true for many Python projects, but not all of them. For some projects, you may need to
 use the optional `python_directory` function argument to customize this. Using the above naming, if your module

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1272,9 +1272,14 @@ def release(_, verbose=False, no_stash=False):
 
         if USE_PULL_REQUEST:
             _checkout_branch(verbose, BRANCH_MASTER)
+
         _post_release(__version__, release_version, pushed_or_rolled_back)
 
-        _standard_output('Release process is complete.')
+        if USE_PULL_REQUEST:
+            _standard_output('You\'re almost done! The release process will be complete when you create '
+                             'a pull request and it is merged.')
+        else:
+            _standard_output('Release process is complete.')
     except ReleaseFailure as e:
         _error_output(e.args[0])
     except subprocess.CalledProcessError as e:

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -608,7 +608,12 @@ def _push_release_changes(release_version, branch_name, verbose):
     elif push == INSTRUCTION_ROLLBACK:
         _standard_output('Rolling back local release commit and tag...')
 
-        _delete_last_commit(verbose)
+        if USE_PULL_REQUEST:
+            _checkout_branch(verbose, BRANCH_MASTER)
+            _delete_branch(verbose, branch_name)
+        else:
+            _delete_last_commit(verbose)
+
         if USE_TAG:
             _delete_local_tag(tag, verbose)
 
@@ -700,6 +705,18 @@ def _checkout_branch(verbose, branch_name):
     )
 
     _verbose_output(verbose, 'Done checking out branch {}.', branch_name)
+
+
+def _delete_branch(verbose, branch_name):
+    _verbose_output(verbose, 'Deleting branch {branch}...', branch=branch_name)
+
+    subprocess.check_call(
+        ['git', 'branch', '-D', branch_name],
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+
+    _verbose_output(verbose, 'Done deleting branch {}.', branch_name)
 
 
 def _create_branch_from_tag(verbose, tag_name, branch_name):

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1187,7 +1187,7 @@ def release(_, verbose=False, no_stash=False):
 
         cl_header, cl_message, cl_footer = _prompt_for_changelog(verbose)
 
-        instruction = _prompt('The release has not yet been committed. Are you ready to commit the it? (Y/n):').lower()
+        instruction = _prompt('The release has not yet been committed. Are you ready to commit it? (Y/n):').lower()
         if instruction and instruction != INSTRUCTION_YES:
             raise ReleaseExit()
 

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1172,7 +1172,7 @@ def release(_, verbose=False, no_stash=False):
     version_regular_expression = RE_VERSION
 
     branch_name = _get_branch_name(verbose)
-    if branch_name != BRANCH_MASTER and not USE_PULL_REQUEST:
+    if branch_name != BRANCH_MASTER:
         if not RE_VERSION_BRANCH_MAJOR.match(branch_name) and not RE_VERSION_BRANCH_MINOR.match(branch_name):
             _error_output(
                 'You are currently on branch "{}" instead of "master." You should only release from master or version '

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1260,7 +1260,8 @@ def release(_, verbose=False, no_stash=False):
         _pre_commit(__version__, release_version)
 
         if USE_PULL_REQUEST:
-            branch_name = 'invoke-release-{}'.format(release_version)
+            current_branch_name = _get_branch_name(verbose)
+            branch_name = 'invoke-release-{}-{}'.format(current_branch_name, release_version)
             _create_branch(verbose, branch_name)
         _commit_release_changes(release_version, cl_message, verbose)
 

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -615,7 +615,7 @@ def _push_release_changes(release_version, branch_name, verbose):
             _delete_last_commit(verbose)
 
         if USE_TAG:
-            _delete_local_tag(tag, verbose)
+            _delete_local_tag(release_version, verbose)
 
         _verbose_output(verbose, 'Finished rolling back local release commit.')
 
@@ -625,12 +625,13 @@ def _push_release_changes(release_version, branch_name, verbose):
         if USE_TAG:
             _print_output(
                 COLOR_RED_BOLD,
-                'Make sure you remember to explicitly push {branch} and the tag (or revert your local changes if you are '
-                'trying to cancel)! You can push with the following commands:\n'
+                'Make sure you remember to explicitly push {branch} and the tag '
+                '(or revert your local changes if you are trying to cancel)! '
+                'You can push with the following commands:\n'
                 '    git push origin {branch}:{branch}\n'
                 '    git push origin "{tag}"\n',
                 branch=branch_name,
-                tag=tag,
+                tag=release_version,
             )
         else:
             _print_output(
@@ -996,7 +997,8 @@ def _post_rollback(current_version, rollback_to_version):
         plugin.post_rollback(ROOT_DIRECTORY, current_version, rollback_to_version)
 
 
-def configure_release_parameters(module_name, display_name, python_directory=None, plugins=None, use_pull_request=False, use_tag=True):
+def configure_release_parameters(module_name, display_name, python_directory=None, plugins=None,
+                                 use_pull_request=False, use_tag=True):
     global MODULE_NAME, MODULE_DISPLAY_NAME, RELEASE_MESSAGE_TEMPLATE, VERSION_FILENAME, CHANGELOG_FILENAME
     global ROOT_DIRECTORY, RELEASE_PLUGINS, PARAMETERS_CONFIGURED, VERSION_FILE_IS_TXT
     global USE_PULL_REQUEST, USE_TAG

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1277,8 +1277,8 @@ def release(_, verbose=False, no_stash=False):
         _post_release(__version__, release_version, pushed_or_rolled_back)
 
         if USE_PULL_REQUEST:
-            _standard_output('You\'re almost done! The release process will be complete when you create '
-                             'a pull request and it is merged.')
+            _standard_output("You're almost done! The release process will be complete when you create "
+                             "a pull request and it is merged.")
         else:
             _standard_output('Release process is complete.')
     except ReleaseFailure as e:


### PR DESCRIPTION
This is to support repositories that don't allow pushing to master, to open pull requests instead.

Give the following contents to the `tasks.py` file in the root directory of your project:
```
from invoke_release.tasks import *  # noqa: F403

configure_release_parameters(  # noqa: F405
    module_name='my_project_python_home_module',
    display_name='My Project Display Name',
    use_pull_request=True,
    use_tag=False
)
```

Instead of pushing the release commit to master, and creating and pushing a tag on this commit, this will:
- create a branch named `invoke-release-<new_version>`
- push the branch to origin
- not create the tag
- checkout master