### PR TITLE
[MINOR] Add support to invoke branch for pull request workflow

### DIFF
--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1198,6 +1198,21 @@ def branch(_, verbose=False, no_stash=False):
                 )
                 _create_branch_from_tag(verbose, branch_version, new_branch)
                 _push_branch(verbose, new_branch)
+
+            cherry_pick_branch_suffix = _prompt(
+                'Now we will create the branch where you will apply your fixes. We\n'
+                'need a name to uniquely idenfity your feature branch. I suggest using\n'
+                'the JIRA ticket id, e.g. EB-120106, of the issue you are working on:'
+            )
+            if not cherry_pick_branch_suffix:
+                raise ReleaseFailure('You must enter a name to identify your feature branch.')
+            _create_branch(
+                verbose,
+                'cherry-pick-{hotfix_branch_name}-{suffix}'.format(
+                    hotfix_branch_name=new_branch,
+                    suffix=cherry_pick_branch_suffix,
+                )
+            )
         else:
             _create_branch_from_tag(verbose, branch_version, new_branch)
 


### PR DESCRIPTION
This is to support repositories that protect hotfix branches, and,
thus, require the use of pull requests to merge into a hotfix branch
instead pushing the hotfix branch directly to origin.

Given the following contents to the `tasks.py` file in the root
directory of your project:

```
from invoke_release.tasks import *  # noqa: F403

configure_release_parameters(  # noqa: F405
    module_name='my_project_python_home_module',
    display_name='My Project Display Name',
    use_pull_request=True,
    use_tag=False
)
```

`invoke branch` will first look for an existing hotfix branch on
origin associated with the input release tag. If found,
`invoke branch` will checkout out a local tracking branch.

If no hotfix branch is found on origin, `invoke branch` will create
one, and push it to origin automatically.