### PR TITLE
Loosen wheel requirement to 'wheel~=0.31'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from invoke_release.version import __version__  # noqa: E402
 install_requires = [
     'invoke~=0.22.0',
     'six~=1.11.0',
-    'wheel~=0.31.1',
+    'wheel~=0.31',
 ]
 
 tests_require = [


### PR DESCRIPTION
CI was failing when pinned to 'wheel~=0.31.1'.