### PR TITLE
Improve `invoke release` workflow by suggesting a version to bump to.

### DIFF
--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1109,7 +1109,7 @@ def _suggest_version(current_version, version_to_bump):
         else:
             suggested_version = _bump_major_version(current_version)
 
-    return '.'.join(map(str, suggested_version)) if suggested_version else ''
+    return '.'.join(map(str, suggested_version)) if suggested_version else None
 
 
 def configure_release_parameters(module_name, display_name, python_directory=None, plugins=None,

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1361,7 +1361,7 @@ def release(_, verbose=False, no_stash=False):
                'Do you want to proceed with the suggested version? (Y/n)'.format(suggested_version)
             ).lower() or INSTRUCTION_YES
 
-        if instruction and instruction == INSTRUCTION_YES:
+        if instruction == INSTRUCTION_YES:
             release_version = suggested_version
         else:
             release_version = _prompt('Enter a new version (or "exit"):').lower()

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1055,11 +1055,11 @@ def _get_version_to_bump(changelog_message):
     patch_commit_present = None
 
     for line in changelog_message:
-        if line.startswith(MAJOR_TAG):
+        if line.startswith('- ' + MAJOR_TAG):
             major_commit_present = True
-        elif line.startswith(MINOR_TAG):
+        elif line.startswith('- ' + MINOR_TAG):
             minor_commit_present = True
-        elif line.startswith(PATCH_TAG):
+        elif line.startswith('- ' + PATCH_TAG):
             patch_commit_present = True
         else:
             # If a line in the changelog message doesn't start with a version

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1054,25 +1054,23 @@ def _get_version_to_bump(changelog_message):
     minor_commit_present = None
     patch_commit_present = None
 
-    if all(
-        MAJOR_TAG in line or
-        MINOR_TAG in line or
-        PATCH_TAG in line
-        for line in changelog_message
-    ):
-        for line in changelog_message:
-            if MAJOR_TAG in line:
-                major_commit_present = True
-            if MINOR_TAG in line:
-                minor_commit_present = True
-            if PATCH_TAG in line:
-                patch_commit_present = True
+    for line in changelog_message:
+        if line.startswith(MAJOR_TAG):
+            major_commit_present = True
+        elif line.startswith(MINOR_TAG):
+            minor_commit_present = True
+        elif line.startswith(PATCH_TAG):
+            patch_commit_present = True
+        else:
+            # If a line in the changelog message doesn't start with a version
+            # tag, suggest nothing.
+            return None
 
-        version = PATCH_TAG if patch_commit_present else None
-        version = MINOR_TAG if minor_commit_present else version
-        version = MAJOR_TAG if major_commit_present else version
+    version = PATCH_TAG if patch_commit_present else None
+    version = MINOR_TAG if minor_commit_present else version
+    version = MAJOR_TAG if major_commit_present else version
 
-        return version
+    return version
 
 
 def _bump_major_version(current_version):
@@ -1361,11 +1359,7 @@ def release(_, verbose=False, no_stash=False):
         _standard_output('Current version: {}', __version__)
 
         cl_header, cl_message, cl_footer = _prompt_for_changelog(verbose)
-        version_according_to_cl_message = _get_version_to_bump(cl_message)
-        suggested_version = _suggest_version(
-            __version__,
-            version_according_to_cl_message,
-        )
+        suggested_version = _suggest_version(__version__, _get_version_to_bump(cl_message))
 
         instruction = None
         if suggested_version:

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -38,6 +38,17 @@ class TestTasks(TestCase):
 
         assert version_to_bump == tasks.MINOR_TAG
 
+    def test_get_version_to_bump_returns_version_only_if_all_commits_start_with_a_tag(self):
+
+        changelog_message = [
+            '[MINOR] A minor-commit message.\n',
+            'A commit message [PATCH] with a tag in between.\n',
+        ]
+
+        version_to_bump = tasks._get_version_to_bump(changelog_message)
+
+        assert version_to_bump is None
+
     def test_get_version_to_bump_returns_none_if_commit_does_not_have_tag(self):
 
         changelog_message = [

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -19,9 +19,9 @@ class TestTasks(TestCase):
     def test_get_version_to_bump_decides_correctly_when_different_multiple_commits(self):
 
         changelog_message = [
-            '[PATCH] A patch-commit message.\n',
-            '[MINOR] A minor-commit message.\n',
-            '[MAJOR] A major-commit message.\n',
+            '- [PATCH] A patch-commit message.\n',
+            '- [MINOR] A minor-commit message.\n',
+            '- [MAJOR] A major-commit message.\n',
         ]
 
         version_to_bump = tasks._get_version_to_bump(changelog_message)
@@ -31,7 +31,7 @@ class TestTasks(TestCase):
     def test_get_version_to_bump_decides_correctly_when_single_commit(self):
 
         changelog_message = [
-            '[MINOR] A minor-commit message.\n',
+            '- [MINOR] A minor-commit message.\n',
         ]
 
         version_to_bump = tasks._get_version_to_bump(changelog_message)
@@ -41,7 +41,7 @@ class TestTasks(TestCase):
     def test_get_version_to_bump_returns_version_only_if_all_commits_start_with_a_tag(self):
 
         changelog_message = [
-            '[MINOR] A minor-commit message.\n',
+            '- [MINOR] A minor-commit message.\n',
             'A commit message [PATCH] with a tag in between.\n',
         ]
 
@@ -52,7 +52,7 @@ class TestTasks(TestCase):
     def test_get_version_to_bump_returns_none_if_commit_does_not_have_tag(self):
 
         changelog_message = [
-            '[MINOR] A minor-commit message.\n',
+            '- [MINOR] A minor-commit message.\n',
             'A commit message with no tag.\n',
         ]
 

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -88,3 +88,11 @@ class TestTasks(TestCase):
         suggested_version = tasks._suggest_version(current_version, tasks.PATCH_TAG)
 
         assert suggested_version == '0.50.2'
+
+    def test_suggest_version_returns_none_if_no_version_to_bump_is_provided(self):
+
+        current_version = '2.50.1'
+
+        suggested_version = tasks._suggest_version(current_version, None)
+
+        assert suggested_version is None

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -26,7 +26,7 @@ class TestTasks(TestCase):
 
         version_element_to_bump = tasks._get_version_element_to_bump_if_any(changelog_message)
 
-        assert version_element_to_bump == tasks.VersionTag.MAJOR_PREFIX
+        assert version_element_to_bump == tasks.MAJOR_VERSION_PREFIX
 
     def test_get_version_element_to_bump_if_any_chooses_minor_if_only_a_minor_commit_is_present(self):
 
@@ -36,7 +36,7 @@ class TestTasks(TestCase):
 
         version_element_to_bump = tasks._get_version_element_to_bump_if_any(changelog_message)
 
-        assert version_element_to_bump == tasks.VersionTag.MINOR_PREFIX
+        assert version_element_to_bump == tasks.MINOR_VERSION_PREFIX
 
     def test_get_version_element_to_bump_if_any_returns_none_if_a_commit_doesnt_have_tag_and_there_is_no_major(self):
 
@@ -58,13 +58,13 @@ class TestTasks(TestCase):
 
         version_element_to_bump = tasks._get_version_element_to_bump_if_any(changelog_message)
 
-        assert version_element_to_bump == tasks.VersionTag.MAJOR_PREFIX
+        assert version_element_to_bump == tasks.MAJOR_VERSION_PREFIX
 
     def test_suggest_version_suggests_a_patch_bump_for_patch_tag(self):
 
         current_version = '1.2.3'
 
-        suggested_version = tasks._suggest_version(current_version, tasks.VersionTag.PATCH_PREFIX)
+        suggested_version = tasks._suggest_version(current_version, tasks.PATCH_VERSION_PREFIX)
 
         assert suggested_version == '1.2.4'
 
@@ -72,7 +72,7 @@ class TestTasks(TestCase):
 
         current_version = '1.2.3+meta.data'
 
-        suggested_version = tasks._suggest_version(current_version, tasks.VersionTag.MINOR_PREFIX)
+        suggested_version = tasks._suggest_version(current_version, tasks.MINOR_VERSION_PREFIX)
 
         assert suggested_version == '1.3.0'
 
@@ -80,7 +80,7 @@ class TestTasks(TestCase):
 
         current_version = '1.2.3-pre.release+meta.data'
 
-        suggested_version = tasks._suggest_version(current_version, tasks.VersionTag.MAJOR_PREFIX)
+        suggested_version = tasks._suggest_version(current_version, tasks.MAJOR_VERSION_PREFIX)
 
         assert suggested_version == '2.0.0'
 
@@ -88,7 +88,7 @@ class TestTasks(TestCase):
 
         current_version = '0.50.1'
 
-        suggested_version = tasks._suggest_version(current_version, tasks.VersionTag.MAJOR_PREFIX)
+        suggested_version = tasks._suggest_version(current_version, tasks.MAJOR_VERSION_PREFIX)
 
         assert suggested_version == '0.51.0'
 
@@ -96,7 +96,7 @@ class TestTasks(TestCase):
 
         current_version = '0.50.1'
 
-        suggested_version = tasks._suggest_version(current_version, tasks.VersionTag.PATCH_PREFIX)
+        suggested_version = tasks._suggest_version(current_version, tasks.PATCH_VERSION_PREFIX)
 
         assert suggested_version == '0.50.2'
 

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -12,6 +12,79 @@ class TestTasks(TestCase):
     """
 
     def test_case_sensitive_regular_file_exists(self):
-        self.assertTrue(tasks._case_sensitive_regular_file_exists(__file__))
-        self.assertFalse(tasks._case_sensitive_regular_file_exists(__file__.upper()))
-        self.assertFalse(tasks._case_sensitive_regular_file_exists(__file__ + '.bogus'))
+        assert tasks._case_sensitive_regular_file_exists(__file__) is True
+        assert tasks._case_sensitive_regular_file_exists(__file__.upper()) is False
+        assert tasks._case_sensitive_regular_file_exists(__file__ + '.bogus') is False
+
+    def test_get_version_to_bump_decides_correctly_when_different_multiple_commits(self):
+
+        changelog_message = [
+            '[PATCH] A patch-commit message.\n',
+            '[MINOR] A minor-commit message.\n',
+            '[MAJOR] A major-commit message.\n',
+        ]
+
+        version_to_bump = tasks._get_version_to_bump(changelog_message)
+
+        assert version_to_bump == tasks.MAJOR_TAG
+
+    def test_get_version_to_bump_decides_correctly_when_single_commit(self):
+
+        changelog_message = [
+            '[MINOR] A minor-commit message.\n',
+        ]
+
+        version_to_bump = tasks._get_version_to_bump(changelog_message)
+
+        assert version_to_bump == tasks.MINOR_TAG
+
+    def test_get_version_to_bump_returns_none_if_commit_does_not_have_tag(self):
+
+        changelog_message = [
+            '[MINOR] A minor-commit message.\n',
+            'A commit message with no tag.\n',
+        ]
+
+        version_to_bump = tasks._get_version_to_bump(changelog_message)
+
+        assert version_to_bump is None
+
+    def test_suggest_version_is_correct_for_a_normal_version(self):
+
+        current_version = '1.2.3'
+
+        suggested_version = tasks._suggest_version(current_version, tasks.PATCH_TAG)
+
+        assert suggested_version == '1.2.4'
+
+    def test_suggest_version_is_correct_for_a_version_with_metadata(self):
+
+        current_version = '1.2.3+meta.data'
+
+        suggested_version = tasks._suggest_version(current_version, tasks.MINOR_TAG)
+
+        assert suggested_version == '1.3.0'
+
+    def test_suggest_version_is_correct_for_a_version_with_pre_release_and_metadata(self):
+
+        current_version = '1.2.3-pre.release+meta.data'
+
+        suggested_version = tasks._suggest_version(current_version, tasks.MAJOR_TAG)
+
+        assert suggested_version == '2.0.0'
+
+    def test_suggest_version_is_correct_for_major_version_zero_and_major_bump(self):
+
+        current_version = '0.50.1'
+
+        suggested_version = tasks._suggest_version(current_version, tasks.MAJOR_TAG)
+
+        assert suggested_version == '0.51.0'
+
+    def test_suggest_version_is_correct_for_major_version_zero_and_patch_bump(self):
+
+        current_version = '0.50.1'
+
+        suggested_version = tasks._suggest_version(current_version, tasks.PATCH_TAG)
+
+        assert suggested_version == '0.50.2'

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -16,7 +16,7 @@ class TestTasks(TestCase):
         assert tasks._case_sensitive_regular_file_exists(__file__.upper()) is False
         assert tasks._case_sensitive_regular_file_exists(__file__ + '.bogus') is False
 
-    def test_get_version_to_bump_decides_correctly_when_different_multiple_commits(self):
+    def test_get_version_element_to_bump_if_any_chooses_major_version_if_a_major_commit_is_present(self):
 
         changelog_message = [
             '- [PATCH] A patch-commit message.\n',
@@ -24,79 +24,79 @@ class TestTasks(TestCase):
             '- [MAJOR] A major-commit message.\n',
         ]
 
-        version_to_bump = tasks._get_version_to_bump(changelog_message)
+        version_element_to_bump = tasks._get_version_element_to_bump_if_any(changelog_message)
 
-        assert version_to_bump == tasks.MAJOR_TAG
+        assert version_element_to_bump == tasks.VersionTag.MAJOR_PREFIX
 
-    def test_get_version_to_bump_decides_correctly_when_single_commit(self):
+    def test_get_version_element_to_bump_if_any_chooses_minor_if_only_a_minor_commit_is_present(self):
 
         changelog_message = [
             '- [MINOR] A minor-commit message.\n',
         ]
 
-        version_to_bump = tasks._get_version_to_bump(changelog_message)
+        version_element_to_bump = tasks._get_version_element_to_bump_if_any(changelog_message)
 
-        assert version_to_bump == tasks.MINOR_TAG
+        assert version_element_to_bump == tasks.VersionTag.MINOR_PREFIX
 
-    def test_get_version_to_bump_returns_version_only_if_all_commits_start_with_a_tag(self):
+    def test_get_version_element_to_bump_if_any_returns_none_if_a_commit_doesnt_have_tag_and_there_is_no_major(self):
 
         changelog_message = [
             '- [MINOR] A minor-commit message.\n',
             'A commit message [PATCH] with a tag in between.\n',
         ]
 
-        version_to_bump = tasks._get_version_to_bump(changelog_message)
+        version_element_to_bump = tasks._get_version_element_to_bump_if_any(changelog_message)
 
-        assert version_to_bump is None
+        assert version_element_to_bump is None
 
-    def test_get_version_to_bump_returns_none_if_commit_does_not_have_tag(self):
+    def test_get_version_element_to_bump_if_any_returns_major_if_commit_does_not_have_tag_but_there_is_a_major(self):
 
         changelog_message = [
-            '- [MINOR] A minor-commit message.\n',
             'A commit message with no tag.\n',
+            '- [MAJOR] A minor-commit message.\n',
         ]
 
-        version_to_bump = tasks._get_version_to_bump(changelog_message)
+        version_element_to_bump = tasks._get_version_element_to_bump_if_any(changelog_message)
 
-        assert version_to_bump is None
+        assert version_element_to_bump == tasks.VersionTag.MAJOR_PREFIX
 
-    def test_suggest_version_is_correct_for_a_normal_version(self):
+    def test_suggest_version_suggests_a_patch_bump_for_patch_tag(self):
 
         current_version = '1.2.3'
 
-        suggested_version = tasks._suggest_version(current_version, tasks.PATCH_TAG)
+        suggested_version = tasks._suggest_version(current_version, tasks.VersionTag.PATCH_PREFIX)
 
         assert suggested_version == '1.2.4'
 
-    def test_suggest_version_is_correct_for_a_version_with_metadata(self):
+    def test_suggest_version_suggests_a_minor_bump_successfully_if_metadata_is_present_for_minor_tag(self):
 
         current_version = '1.2.3+meta.data'
 
-        suggested_version = tasks._suggest_version(current_version, tasks.MINOR_TAG)
+        suggested_version = tasks._suggest_version(current_version, tasks.VersionTag.MINOR_PREFIX)
 
         assert suggested_version == '1.3.0'
 
-    def test_suggest_version_is_correct_for_a_version_with_pre_release_and_metadata(self):
+    def test_suggest_version_suggests_a_major_bump_if_metadata_and_prerelease_info_is_present_for_major_Tag(self):
 
         current_version = '1.2.3-pre.release+meta.data'
 
-        suggested_version = tasks._suggest_version(current_version, tasks.MAJOR_TAG)
+        suggested_version = tasks._suggest_version(current_version, tasks.VersionTag.MAJOR_PREFIX)
 
         assert suggested_version == '2.0.0'
 
-    def test_suggest_version_is_correct_for_major_version_zero_and_major_bump(self):
+    def test_suggest_version_suggests_minor_bump_for_major_version_zero_and_major_tag(self):
 
         current_version = '0.50.1'
 
-        suggested_version = tasks._suggest_version(current_version, tasks.MAJOR_TAG)
+        suggested_version = tasks._suggest_version(current_version, tasks.VersionTag.MAJOR_PREFIX)
 
         assert suggested_version == '0.51.0'
 
-    def test_suggest_version_is_correct_for_major_version_zero_and_patch_bump(self):
+    def test_suggest_version_suggests_patch_bump_for_major_version_zero_and_patch_bump(self):
 
         current_version = '0.50.1'
 
-        suggested_version = tasks._suggest_version(current_version, tasks.PATCH_TAG)
+        suggested_version = tasks._suggest_version(current_version, tasks.VersionTag.PATCH_PREFIX)
 
         assert suggested_version == '0.50.2'
 


### PR DESCRIPTION
The goal of this PR is to improve the workflow of `invoke release` by displaying the CHANGELOG messages _before_ asking for a new version and, whenever possible, even suggesting a version.

The new workflow would look like this:


```
➜ invoke release
Invoke Release 4.2.0
Releasing Artist service...
Current version: 5.43.1
Would you like to enter changelog details for this release? (Y/n/exit):
Would you like to gather commit messages from recent commits and add them to the changelog? (Y/n/exit):
According to the CHANGELOG message the next version should be `5.44.0`. Do you want to proceed with the suggested version? y
The release has not yet been committed. Are you ready to commit it? (Y/n): n
```

```
➜ invoke release
Invoke Release 4.2.0
Releasing Artist service...
Current version: 5.43.1
Would you like to enter changelog details for this release? (Y/n/exit):
Would you like to gather commit messages from recent commits and add them to the changelog? (Y/n/exit):
According to the CHANGELOG message the next version should be `5.44.0`. Do you want to proceed with the suggested version? (y/N)
Enter a new version (or "exit"): 5.44.0
The release has not yet been committed. Are you ready to commit it? (Y/n): n
```


Even from a MAJOR/MINOR _branch_ the suggestion would gather the commits made in that branch and would suggest according to the changelog in there.


* Version `0.x.x` where any MAJOR/MINOR bump would only bump a MINOR version [DONE - Updated]
* It should validate that _every_ entry in the changelog message has a [MAJOR] / [MINOR] / [PATCH] tag to even consider suggesting a version. [DONE - Updated]