### PR TITLE
Fix open pr

### DIFF
--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1437,10 +1437,10 @@ def release(_, verbose=False, no_stash=False):
         if USE_PULL_REQUEST:
             if current_branch_name != BRANCH_MASTER:
                 _checkout_branch(verbose, current_branch_name)
-            pr_opened = ''
             try:
                 github_token = os.environ['GITHUB_TOKEN']
             except KeyError:
+                pr_opened = False
                 _standard_output('Then environment variable `GITHUB_TOKEN` is not set. Will not open GitHub PR.')
             else:
                 pr_opened = open_pull_request(branch_name, current_branch_name, release_version, github_token)
@@ -1621,6 +1621,7 @@ def open_pull_request(branch_name, current_branch_name, version_to_release, gith
     try:
         req = urllib.request.Request(url, body, headers)
         with closing(urllib.request.urlopen(req)) as f:
+            # GitHub will always answer with 201 if the PR was `CREATED`.
             return f.getcode() == 201 and json.loads(f.read().decode('utf-8'))['html_url']
     except Exception:
         _error_output('Could not open Github PR')

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
 import codecs
+from contextlib import closing
 import datetime
+import json
 import os
 import re
 import shlex
@@ -13,11 +15,8 @@ from distutils.version import LooseVersion
 from invoke import task
 import six
 from six import moves
-from wheel import archive
-
-from contextlib import closing
-import json
 from six.moves import urllib
+from wheel import archive
 
 RE_CHANGELOG_FILE_HEADER = re.compile(r'^=+$')
 RE_CHANGELOG_VERSION_HEADER = re.compile(r'^-+$')
@@ -1439,16 +1438,22 @@ def release(_, verbose=False, no_stash=False):
             if current_branch_name != BRANCH_MASTER:
                 _checkout_branch(verbose, current_branch_name)
             try:
-                github_token = os.environ["GITHUB_TOKEN"]
+                github_token = os.environ['GITHUB_TOKEN']
             except KeyError:
-                _standard_output("GITHUB_TOKEN env var not set. Unable to open a github PR")
+                pr_opened = False
+                _standard_output('`GITHUB_TOKEN` environment variable not set. Will not open GitHub PR.')
             else:
-                open_pull_request(branch_name, current_branch_name, release_version, github_token)
+                pr_opened = open_pull_request(branch_name, current_branch_name, release_version, github_token)
         _post_release(__version__, release_version, pushed_or_rolled_back)
 
         if USE_PULL_REQUEST:
-            _standard_output("You're almost done! The release process will be complete when you create "
-                             "a pull request and it is merged.")
+            if not pr_opened:
+                _standard_output(
+                    "You're almost done! The release process will be complete when you create "
+                    "a pull request and it is merged."
+                )
+            else:
+                _standard_output('GitHub PR created successfully.')
         else:
             _standard_output('Release process is complete.')
     except ReleaseFailure as e:
@@ -1589,31 +1594,34 @@ def wheel(_):
     ))
 
 
-def open_pull_request(base, head, title, token):
-    remote = subprocess.check_output(
-        ['git', 'remote', 'get-url', 'origin'],
-        stderr=subprocess.STDOUT,
+def open_pull_request(branch_name, current_branch_name, version_to_release, github_token):
+    remote = six.text_type(
+        subprocess.check_output(
+            ['git', 'remote', 'get-url', 'origin'],
+            stderr=subprocess.STDOUT,
         )
+    )
     repo = (remote.split(':')[1].split('.')[0])
-    url = 'https://api.github.com/repos/{}/pulls'.format(repo)
+    url = 'http://api.github.com/repos/{}/pulls'.format(repo)
 
     values = {
-      'title': title,
-      'base': base,
-      'head': head
+        'title': 'Released version {}'.format(version_to_release),
+        'base': current_branch_name,
+        'head': branch_name,
     }
 
     body = json.dumps(values).encode('utf-8')
     headers = {
         'Content-Type': 'application/json',
-        'Authorization': 'token {}'.format(token),
+        'Authorization': 'token {}'.format(github_token),
         'Accept': 'application/vnd.github.v3+json',
-        'Content-Length': len(body)
+        'Content-Length': len(body),
     }
 
     try:
         req = urllib.request.Request(url, body, headers)
         with closing(urllib.request.urlopen(req)) as f:
             f.read()
+            return f.status == 200
     except Exception:
         _error_output('Could not open Github PR')


### PR DESCRIPTION
The new flow would look like this:

```
➜ invoke release
Invoke Release 4.4.0
Releasing Test Guillaume...
Current version: 0.4.18
Would you like to enter changelog details for this release? (Y/n/exit): n
Enter a new version (or "exit"): 0.4.20
The release has not yet been committed. Are you ready to commit it? (Y/n):
Releasing Test Guillaume version: 0.4.20
M       test_devtools/version.py
Switched to a new branch 'invoke-release-master-0.4.20'
[invoke-release-master-0.4.20 76c2933] Released Test Guillaume version 0.4.20
 1 file changed, 1 insertion(+), 1 deletion(-)
Push release changes to remote origin (branch "invoke-release-master-0.4.20")? (y/N/rollback): y
Counting objects: 4, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 429 bytes | 429.00 KiB/s, done.
Total 4 (delta 2), reused 0 (delta 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
remote:
remote: Create a pull request for 'invoke-release-master-0.4.20' on GitHub by visiting:
remote:      https://github.com/eventbrite/test-devtools/pull/new/invoke-release-master-0.4.20
remote:
To github.com:eventbrite/test-devtools.git
 * [new branch]      invoke-release-master-0.4.20 -> invoke-release-master-0.4.20
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Deleted branch invoke-release-master-0.4.20 (was 76c2933).
Already on 'master'
Your branch is up to date with 'origin/master'.
GitHub PR created successfully. URL: https://github.com/eventbrite/test-devtools/pull/128
```


If you don't have `GITHUB_TOKEN` set:
```
➜ invoke release
Invoke Release 4.4.0
Releasing Test Guillaume...
Current version: 0.4.6
Would you like to enter changelog details for this release? (Y/n/exit):
Would you like to gather commit messages from recent commits and add them to the changelog? (Y/n/exit):
Enter a new version (or "exit"): 0.4.11
The release has not yet been committed. Are you ready to commit it? (Y/n):
Releasing Test Guillaume version: 0.4.11
M       test_devtools/version.py
Switched to a new branch 'invoke-release-master-0.4.11'
[invoke-release-master-0.4.11 08ca4e9] Released Test Guillaume version 0.4.11
 1 file changed, 1 insertion(+), 1 deletion(-)
Push release changes to remote origin (branch "invoke-release-master-0.4.11")? (y/N/rollback): y
Counting objects: 4, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 429 bytes | 429.00 KiB/s, done.
Total 4 (delta 2), reused 0 (delta 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
remote:
remote: Create a pull request for 'invoke-release-master-0.4.11' on GitHub by visiting:
remote:      https://github.com/eventbrite/test-devtools/pull/new/invoke-release-master-0.4.11
remote:
To github.com:eventbrite/test-devtools.git
 * [new branch]      invoke-release-master-0.4.11 -> invoke-release-master-0.4.11
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Deleted branch invoke-release-master-0.4.11 (was 08ca4e9).
Already on 'master'
Your branch is up to date with 'origin/master'.
Then environment variable `GITHUB_TOKEN` is not set. Will not open GitHub PR.
You're almost done! The release process will be complete when you create a pull request and it is merged.
```

If you do have the `GITHUB_TOKEN` set but it's wrong or don't have enough permissions or smth:
```
➜ invoke release
Invoke Release 4.4.0
Releasing Test Guillaume...
Current version: 0.4.14
Would you like to enter changelog details for this release? (Y/n/exit):
Would you like to gather commit messages from recent commits and add them to the changelog? (Y/n/exit):
Enter a new version (or "exit"): 0.4.18
The release has not yet been committed. Are you ready to commit it? (Y/n):
Releasing Test Guillaume version: 0.4.18
M       test_devtools/version.py
Switched to a new branch 'invoke-release-master-0.4.18'
[invoke-release-master-0.4.18 620bbfc] Released Test Guillaume version 0.4.18
 1 file changed, 1 insertion(+), 1 deletion(-)
Push release changes to remote origin (branch "invoke-release-master-0.4.18")? (y/N/rollback):
Not pushing changes to remote origin!
Make sure you remember to explicitly push invoke-release-master-0.4.18 (or revert your local changes if you are trying to cancel)! You can push with the following command:
    git push origin invoke-release-master-0.4.18:invoke-release-master-0.4.18
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
ERROR: Could not open Github PR
You're almost done! The release process will be complete when you create a pull request and it is merged.
```

Also this was tested in py2 and py3 to verify compatibiltiy.