### PR TITLE
[PATCH] Fix GitHub PRs workflow when not pushing branch 

### DIFF
--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1435,7 +1435,7 @@ def release(_, verbose=False, no_stash=False):
             _tag_branch(release_version, cl_message, verbose)
         pushed_or_rolled_back = _push_release_changes(release_version, branch_name, verbose)
 
-        uses_prs_and_branch_is_pushed = USE_PULL_REQUEST and pushed_or_rolled_back == PUSH_RESULT_PUSHED:
+        uses_prs_and_branch_is_pushed = USE_PULL_REQUEST and pushed_or_rolled_back == PUSH_RESULT_PUSHED
 
         if uses_prs_and_branch_is_pushed:
             if current_branch_name != BRANCH_MASTER:

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1435,7 +1435,9 @@ def release(_, verbose=False, no_stash=False):
             _tag_branch(release_version, cl_message, verbose)
         pushed_or_rolled_back = _push_release_changes(release_version, branch_name, verbose)
 
-        if USE_PULL_REQUEST and pushed_or_rolled_back == PUSH_RESULT_PUSHED:
+        uses_prs_and_branch_is_pushed = USE_PULL_REQUEST and pushed_or_rolled_back == PUSH_RESULT_PUSHED:
+
+        if uses_prs_and_branch_is_pushed:
             if current_branch_name != BRANCH_MASTER:
                 _checkout_branch(verbose, current_branch_name)
             try:
@@ -1453,7 +1455,7 @@ def release(_, verbose=False, no_stash=False):
                 )
         _post_release(__version__, release_version, pushed_or_rolled_back)
 
-        if USE_PULL_REQUEST and pushed_or_rolled_back == PUSH_RESULT_PUSHED:
+        if uses_prs_and_branch_is_pushed:
             if pr_opened:
                 _standard_output('GitHub PR created successfully. URL: {}'.format(pr_opened))
             else:

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1435,7 +1435,7 @@ def release(_, verbose=False, no_stash=False):
             _tag_branch(release_version, cl_message, verbose)
         pushed_or_rolled_back = _push_release_changes(release_version, branch_name, verbose)
 
-        if USE_PULL_REQUEST:
+        if USE_PULL_REQUEST and pushed_or_rolled_back == PUSH_RESULT_PUSHED:
             if current_branch_name != BRANCH_MASTER:
                 _checkout_branch(verbose, current_branch_name)
             try:
@@ -1453,7 +1453,7 @@ def release(_, verbose=False, no_stash=False):
                 )
         _post_release(__version__, release_version, pushed_or_rolled_back)
 
-        if USE_PULL_REQUEST:
+        if USE_PULL_REQUEST and pushed_or_rolled_back == PUSH_RESULT_PUSHED:
             if pr_opened:
                 _standard_output('GitHub PR created successfully. URL: {}'.format(pr_opened))
             else:


### PR DESCRIPTION
If you don't want to push changes right now, it tries to open a PR anyway:
```
➜  soa_proxy_service git:(master) invoke release
Invoke Release 4.4.3
Releasing Legacy SOA Transition Proxy Service...
Current version: 1.32.0
Would you like to enter changelog details for this release? (Y/n/exit): 
Would you like to gather commit messages from recent commits and add them to the changelog? (Y/n/exit): 
According to the changelog message the next version should be `1.32.1`. Do you want to proceed with the suggested version? (Y/n) 
The release has not yet been committed. Are you ready to commit it? (Y/n): 
Releasing Legacy SOA Transition Proxy Service version: 1.32.1
M       CHANGELOG.txt
M       soa_proxy_service/version.py
Switched to a new branch 'invoke-release-master-1.32.1'
[invoke-release-master-1.32.1 0229889] Released Legacy SOA Transition Proxy Service version 1.32.1
 2 files changed, 5 insertions(+), 1 deletion(-)
Push release changes to remote origin (branch "invoke-release-master-1.32.1")? (y/N/rollback): 
Not pushing changes to remote origin!
Make sure you remember to explicitly push invoke-release-master-1.32.1 (or revert your local changes if you are trying to cancel)! You can push with the following command:
    git push origin invoke-release-master-1.32.1:invoke-release-master-1.32.1
ERROR: Could not open Github PR
You're almost done! The release process will be complete when you create a pull request and it is merged.
```

That should not happen.