### PR TITLE
[PATCH] Minor fix regex character set in non-default branch

### DIFF
--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1366,7 +1366,7 @@ def release(_, verbose=False, no_stash=False):
             return
 
         version_regular_expression = re.compile(
-            r'^' + branch_name.replace('.x', r'.\d+').replace('.', r'\.') + r'([a-zA-Z\d.-]*[a-zA-Z\d]+)?$',
+            r'^' + branch_name.replace('.x', r'.\d+').replace('.', r'\.') + r'([a-zA-Z\d.-+]*[a-zA-Z\d]+)?$',
         )
 
     try:

--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -1366,7 +1366,7 @@ def release(_, verbose=False, no_stash=False):
             return
 
         version_regular_expression = re.compile(
-            r'^' + branch_name.replace('.x', r'.\d+').replace('.', r'\.') + r'([a-zA-Z\d.-+]*[a-zA-Z\d]+)?$',
+            r'^' + branch_name.replace('.x', r'.\d+').replace('.', r'\.') + r'([a-zA-Z\d.+-]*[a-zA-Z\d]+)?$',
         )
 
     try:


### PR DESCRIPTION
Releasing from a separate (non-default) branch, [regex](https://github.com/eventbrite/invoke-release/blob/4.6.0/python/invoke_release/tasks.py#L1369) wouldn't match a `+` sign inside branch name, as it does in the default branch case, where [RE_VERSION](https://github.com/eventbrite/invoke-release/blob/4.6.0/python/invoke_release/tasks.py#L25) is [used](https://github.com/eventbrite/invoke-release/blob/4.6.0/python/invoke_release/tasks.py#L1340).