### PR TITLE
[MINOR] Fix Python 3.12+ compatibility (drop distutils, six, pkg_resources)

### DIFF
--- a/python/invoke_release/tasks.py
+++ b/python/invoke_release/tasks.py
@@ -3,21 +3,18 @@ from __future__ import absolute_import, unicode_literals
 import codecs
 from contextlib import closing
 import datetime
-from distutils.version import LooseVersion
+import importlib
 import json
 import os
-from pkg_resources import parse_version
 import re
 import shlex
 import subprocess
 import sys
 import tempfile
+import urllib.request
 
 from invoke import task
-import six
-from six import moves
-from six.moves import urllib
-from wheel import archive
+from packaging.version import Version, parse as parse_version
 
 RE_CHANGELOG_FILE_HEADER = re.compile(r'^=+$')
 RE_CHANGELOG_VERSION_HEADER = re.compile(r'^-+$')
@@ -143,12 +140,8 @@ def _standard_output(message, *args, **kwargs):
 
 def _prompt(message, *args, **kwargs):
     _print_output(COLOR_WHITE, message + ' ', *args, **kwargs)
-    # noinspection PyCompatibility
-    response = moves.input()
+    response = input()
     if response:
-        if not isinstance(response, six.text_type):
-            # Input returns a bytestring in Python 2 and a unicode string in Python 3
-            return response.decode('utf8').strip()
         return response.strip()
     return ''
 
@@ -329,7 +322,7 @@ def _prompt_for_changelog(verbose):
     if len(built_up_changelog) > 0:
         _verbose_output(verbose, 'Read {} lines of built-up changelog text:', len(built_up_changelog))
         if verbose:
-            _verbose_output(verbose, six.text_type(built_up_changelog))
+            _verbose_output(verbose, str(built_up_changelog))
         _standard_output('There are existing changelog details for this release. You can "edit" the changes, '
                          '"accept" them as-is, delete them and create a "new" changelog message, or "delete" '
                          'them and enter no changelog.')
@@ -1242,9 +1235,9 @@ def branch(_, verbose=False, no_stash=False):
         if branch_version not in tags:
             raise ReleaseFailure('Version number {} not in the list of available tags.'.format(branch_version))
 
-        _v = LooseVersion(branch_version)
-        minor_branch = '.'.join(list(map(six.text_type, _v.version[:2])) + ['x'])
-        major_branch = '.'.join(list(map(six.text_type, _v.version[:1])) + ['x', 'x'])
+        _v = Version(branch_version).release
+        minor_branch = '.'.join(list(map(str, _v[:2])) + ['x'])
+        major_branch = '.'.join(list(map(str, _v[:1])) + ['x', 'x'])
 
         proceed_instruction = _prompt(
             'Using tag {tag}, would you like to create a minor branch for patch versions (branch {minor}, '
@@ -1419,7 +1412,7 @@ def release(_, verbose=False, no_stash=False):
         else:
             version_info = list(map(int, version_info))
         release_version = version_separator.join(
-            filter(None, ['.'.join(map(six.text_type, version_info[:3])), (version_info[3:] or [None])[0]])
+            filter(None, ['.'.join(map(str, version_info[:3])), (version_info[3:] or [None])[0]])
         )  # This must match the code in VERSION_VARIABLE_TEMPLATE at the top of this file
 
         if not (parse_version(release_version) > parse_version(__version__)):
@@ -1586,8 +1579,7 @@ def rollback_release(_, verbose=False, no_stash=False):
                 _standard_output('The commit was not reverted.')
 
             version_module = __import__('{}.version'.format(MODULE_NAME), fromlist=[str('__version__')])
-            # noinspection PyCompatibility
-            moves.reload_module(version_module)
+            importlib.reload(version_module)
             _post_rollback(__version__, version_module.__version__)
 
             _standard_output('Release rollback is complete.')
@@ -1615,6 +1607,17 @@ def wheel(_):
 
     Future possible changes: Upload to the wheel server.
     """
+    # `wheel.archive` was removed in wheel 0.32. On modern environments we
+    # cannot run this task; on older environments (wheel <0.32) it still works.
+    try:
+        from wheel import archive  # noqa: F401  (lazy import on purpose)
+    except ImportError:
+        raise ReleaseFailure(
+            'The `invoke wheel` task requires `wheel<0.32` (the `wheel.archive` '
+            'module was removed in wheel 0.32). Build wheels with '
+            '`python -m build --wheel` instead.'
+        )
+
     build_instruction = _prompt('Build a wheel archive of {}? (Y/n):'.format(MODULE_DISPLAY_NAME)).lower()
 
     if build_instruction == INSTRUCTION_NO:
@@ -1630,11 +1633,10 @@ def wheel(_):
 
 
 def open_pull_request(branch_name, current_branch_name, display_name, version_to_release, github_token):
-    remote = six.text_type(
-        subprocess.check_output(
-            ['git', 'remote', 'get-url', 'origin'],
-            stderr=subprocess.STDOUT,
-        )
+    remote = subprocess.check_output(
+        ['git', 'remote', 'get-url', 'origin'],
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
     )
     repo = (remote.split(':')[1].split('.')[0])
     url = 'https://api.github.com/repos/{}/pulls'.format(repo)

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ from invoke_release.version import __version__  # noqa: E402
 
 # No dependencies to keep the library lightweight
 install_requires = [
-    'invoke~=0.22.0',
-    'six~=1.11.0',
-    'wheel~=0.31.1'
+    'invoke>=1.0,<3.0',
+    'packaging>=20.0',
+    'wheel>=0.31.1',
 ]
 
 tests_require = [


### PR DESCRIPTION
## Summary

The pinned `invoke==0.22.0` (2017) and direct use of removed/deprecated stdlib APIs prevent `invoke-release` from running on Python 3.12+ (and partially on 3.11). This PR makes the tool work on modern Python while staying backwards-compatible to Python 3.6+.

## What breaks today

| API | Python version | Breakage |
|---|---|---|
| `distutils.version.LooseVersion` | removed in 3.12 | `ImportError` at module load |
| `pkg_resources.parse_version` | deprecated | runtime `DeprecationWarning`, removal pending |
| `wheel.archive.make_wheelfile_inner` | removed in `wheel` 0.32 | `ImportError` at module load |
| `invoke==0.22.0` (vendored `six.moves`) | broken on 3.12+ | `ModuleNotFoundError: invoke.vendor.six.moves` |
| `imp.load_module` (used by old invoke) | removed in 3.12 | crash on first `invoke <task>` |

## Changes

`setup.py`:
- `invoke~=0.22.0` -> `invoke>=1.0,<3.0`
- Drop `six~=1.11.0`
- Add `packaging>=20.0`

`python/invoke_release/tasks.py`:
- `distutils.version.LooseVersion` -> `packaging.version.Version` (using `.release` instead of `.version`)
- `pkg_resources.parse_version` -> `packaging.version.parse`
- `from wheel import archive` (top-level) -> lazy try/except inside the `wheel()` task. If running on `wheel<0.32` the task still works; on modern wheel it raises a clear `ReleaseFailure` pointing to `python -m build --wheel`.
- `six.text_type` -> `str`; `six.moves.input` -> `input`; `six.moves.reload_module` -> `importlib.reload`; `six.moves.urllib` -> stdlib `urllib.request`.
- `subprocess.check_output(...)` for `git remote get-url` now uses `universal_newlines=True` (3.0+ alias for `text=`) so we get a `str` directly instead of relying on `six.text_type` to coerce bytes.

## Compatibility

- **Python**: 3.6+ (uses `importlib.reload` which is 3.4+, `packaging` available everywhere, `universal_newlines=True` works on all py3).
- **`invoke`**: pin widened to `>=1.0,<3.0` so pip picks the latest version compatible with the host Python (1.x on older Py, 2.x on Py 3.6+).
- **`wheel`**: floor unchanged at `>=0.31.1`. Modern wheel works for everything except the `invoke wheel` task — which has been broken anyway since wheel 0.32.

## Validated on

Python 3.14.4, fresh venv, editable install, `invoke version` against an actual ebutils checkout:

```
Python 3.14.4 (main, Apr 14 2026, 14:46:33) [Clang 22.1.3 ]
Invoke 2.2.1
Invoke Release 4.6.0
Eventbrite Common Utilities Library 4.1.0
```

`invoke --help release` and `invoke --list` both render correctly.

## Note on PR #51

PR #51 (Aug 2025) covers some of the same ground — it drops `six` calls and Py 2 boilerplate. However it leaves the actual Py 3.12+ breakage in place: `distutils`, `pkg_resources`, `wheel.archive`, and uses a bare `reload()` call that does not exist as a builtin in Python 3 (it would `NameError` at runtime in the rollback-release task). This PR is complementary; rebasing onto #51 if it lands is a small mechanical job.

## Test plan

- [ ] `pip install -e .` succeeds on Python 3.6, 3.9, 3.12, 3.14
- [ ] `invoke version` runs in a project with `tasks.py` + `version.py` + `CHANGELOG.txt`
- [ ] `invoke release --no-stash` produces the expected commit shape (manually verified by reading the patched code paths against ebutils' history; not yet end-to-end tested against a real release)
- [ ] `invoke wheel` raises a clear error message on modern wheel; still works if `wheel<0.32` is pinned